### PR TITLE
Ok feedback icons missing if disabled validators

### DIFF
--- a/src/js/bootstrapValidator.js
+++ b/src/js/bootstrapValidator.js
@@ -1040,8 +1040,18 @@ if (typeof jQuery === 'undefined') {
 
                     case this.STATUS_VALID:
                         // If the field is valid (passes all validators)
-                        isValidField = ($allErrors.filter('[data-bv-result="' + this.STATUS_NOT_VALIDATED +'"]').length === 0)
-                                     ? ($allErrors.filter('[data-bv-result="' + this.STATUS_VALID +'"]').length === $allErrors.length)  // All validators are completed
+                        var $notValidated = $allErrors.filter('[data-bv-result="' + this.STATUS_NOT_VALIDATED +'"]');
+                        var dismissableLength = 0;
+                        var bsValidator = this;
+                        $notValidated.each( function (i) {
+                            var validatorName = $(this).attr('data-bv-validator');
+                            if (bsValidator.options.fields[field].validators[validatorName].enabled === false) {
+                                dismissableLength += 1;
+                            }
+                        });
+
+                        isValidField = ($allErrors.filter('[data-bv-result="' + this.STATUS_NOT_VALIDATED +'"]').length - dismissableLength === 0)
+                                     ? ($allErrors.filter('[data-bv-result="' + this.STATUS_VALID +'"]').length + dismissableLength === $allErrors.length)  // All validators are completed
                                      : null;                                                                                            // There are some validators that have not done
                         if (isValidField !== null) {
                             this.disableSubmitButtons(this.$submitButton ? !this.isValid() : !isValidField);


### PR DESCRIPTION
Hi Phuoc. The field validation seems erroneous in the case a field understands both disabled and enabled validators. The parent group is correctly added the has-success success class, but because disabled validators are considered "NOT_VALIDATED", the Ok-feedback icons are not set.
