### PR TITLE
Ignore bogus events on IE (fixes #1040)

### DIFF
--- a/test/spec/live.js
+++ b/test/spec/live.js
@@ -1,0 +1,81 @@
+describe('live', function() {
+    // Override the options
+    $.extend($.fn.bootstrapValidator.DEFAULT_OPTIONS, {
+        feedbackIcons: {
+            valid: 'glyphicon glyphicon-ok',
+            invalid: 'glyphicon glyphicon-remove',
+            validating: 'glyphicon glyphicon-refresh'
+        }
+    });
+
+    beforeEach(function(done) {
+        $([
+            '<form class="form-horizontal" id="inputForm">',
+                '<div class="form-group">',
+                    '<textarea name="text" data-bv-notempty placeholder="Text" />',
+                '</div>',
+                '<div class="form-group">',
+                    '<input type="text" name="input1" data-bv-notempty placeholder="Text" />',
+                '</div>',
+                '<div class="form-group">',
+                    '<input type="text" name="input2" data-bv-notempty placeholder="Café" />',
+                '</div>',
+            '</form>'
+        ].join('\n')).appendTo('body');
+
+        $('#inputForm').bootstrapValidator();
+
+        this.bv      = $('#inputForm').data('bootstrapValidator');
+        this.$text   = this.bv.getFieldElements('text');
+        this.$input1 = this.bv.getFieldElements('input1');
+        this.$input2 = this.bv.getFieldElements('input2');
+        setTimeout(done, 0);
+    });
+
+    afterEach(function() {
+        $('#inputForm').bootstrapValidator('destroy').remove();
+    });
+
+    // #1040
+    it('fields should not be validated on init', function() {
+        expect(this.bv.getMessages(this.$text)).toEqual([]);
+        expect(this.bv.getMessages(this.$input1)).toEqual([]);
+        expect(this.bv.getMessages(this.$input2)).toEqual([]);
+    });
+
+    // IE11, see https://connect.microsoft.com/IE/feedback/details/810538/ie-11-fires-input-event-on-focus
+    it('fields should not be validated on focus', function() {
+        this.$text.focus();
+        expect(this.bv.getMessages(this.$text)).toEqual([]);
+        this.$input1.focus();
+        expect(this.bv.getMessages(this.$input1)).toEqual([]);
+        this.$input2.focus();
+        expect(this.bv.getMessages(this.$input2)).toEqual([]);
+    });
+
+    it('fields should be validated on input', function() {
+        fill(this.$input1, 'text');
+        expect(this.bv.getMessages(this.$input1)).toEqual([]);
+        fill(this.$input1, '');
+        expect(this.bv.getMessages(this.$input1)).not.toEqual([]);
+    });
+
+    it('fields should not be unvalidated on blur', function() {
+        this.$input1.focus();
+        triggerInput(this.$input1);
+        fill(this.$input1, 'text');
+        fill(this.$input1, '');
+        this.$input1.blur();
+        expect(this.bv.getMessages(this.$input1)).not.toEqual([]);
+    });
+
+    function fill($input, val) {
+        $input.val(val);
+        triggerInput($input);
+    }
+
+    function triggerInput($input) {
+        $input.trigger("keyup"); // for IE9
+        $input.trigger("input"); // for anything else
+    }
+});

--- a/test/spec/validator/choice.js
+++ b/test/spec/validator/choice.js
@@ -1,0 +1,99 @@
+describe('choice', function() {
+    beforeEach(function() {
+        $([
+            '<form class="form-horizontal" id="choiceForm">',
+                '<div class="form-group">',
+                    '<input type="checkbox" name="group1" value="val1" />',
+                '</div>',
+                '<div class="form-group">',
+                    '<input type="checkbox" name="group1" value="val2" />',
+                '</div>',
+                '<div class="form-group">',
+                    '<input type="checkbox" name="group1" value="val3" />',
+                '</div>',
+                '<div class="form-group">',
+                    '<input type="checkbox" name="group1" value="val4" />',
+                '</div>',
+                '<div class="form-group">',
+                    '<input type="checkbox" name="group1" value="val5" />',
+                '</div>',
+                '<div class="form-group">',
+                    '<input type="checkbox" name="group2" value="val1" />',
+                '</div>',
+            '</form>'
+        ].join('\n')).appendTo('body');
+
+        $('#choiceForm').bootstrapValidator({
+            fields: {
+                group1: {
+                    validators: {
+                        choice: {
+                            min: 2,
+                            max: 3,
+                            message: 'Please choose 2 - 3 choices'
+                        }
+                    }
+                },
+                group2: {
+                    validators: {
+                        choice: {
+                            min: 1,
+                            max: 1,
+                            message: 'Please check the checkbox'
+                        }
+                    }
+                }
+            }
+        });
+
+        this.bv   = $('#choiceForm').data('bootstrapValidator');
+    });
+
+    afterEach(function() {
+        $('#choiceForm').bootstrapValidator('destroy').remove();
+    });
+
+    it('Not enough choices', function() {
+        this.bv.resetForm();
+        check('group1', 'val1', true);
+        this.bv.validate();
+        expect(this.bv.isValid()).toBeFalsy();
+    });
+
+    it('Enough choices', function() {
+        this.bv.resetForm();
+        check('group1', 'val1', true);
+        check('group1', 'val2', true);
+        check('group2', 'val1', true);
+        this.bv.validate();
+        expect(this.bv.isValid()).toBeTruthy();
+    });
+
+    it('Multiple validate', function() {
+        this.bv.resetForm();
+        check('group1', 'val1', true);
+        check('group1', 'val2', true);
+        this.bv.validate();
+        expect(this.bv.isValid()).toBeFalsy();
+        check('group2', 'val1', true);
+        this.bv.validate();
+        expect(this.bv.isValid()).toBeTruthy();
+    });
+
+    it('Too much choices', function() {
+        this.bv.resetForm();
+        check('group1', 'val1', true);
+        check('group1', 'val2', true);
+        check('group1', 'val3', true);
+        check('group1', 'val4', true);
+        check('group2', 'val1', true);
+        this.bv.validate();
+        expect(this.bv.isValid()).toBeFalsy();
+    });
+
+    function check(name, value, checked) {
+        $('input[name='+name+'][value='+value+']')
+            .prop('checked', true)
+            .trigger('change');
+    }
+});


### PR DESCRIPTION
It fixes it better than #1041. It also fixes the validation on focus on IE11.
