### PR TITLE
check for not validated fields in isValidContainer method

### DIFF
--- a/src/js/bootstrapValidator.js
+++ b/src/js/bootstrapValidator.js
@@ -1311,7 +1311,7 @@ if (typeof jQuery === 'undefined') {
                 var $f = map[field];
                 if ($f.data('bv.messages')
                       .find('.help-block[data-bv-validator][data-bv-for="' + field + '"]')
-                      .filter('[data-bv-result="' + this.STATUS_INVALID +'"]')
+                      .filter('[data-bv-result="' + this.STATUS_INVALID +'"], [data-bv-result="' + this.STATUS_NOT_VALIDATED +'"]')
                       .length > 0)
                 {
                     return false;


### PR DESCRIPTION
I suggest that we check for any not validated fields in isValidContainer method as we do not want to run the validate method on the form before calling this method as that will highlight all other fields.
