### PR TITLE
Added ability to filter by card types

### DIFF
--- a/src/js/validator/creditCard.js
+++ b/src/js/validator/creditCard.js
@@ -10,12 +10,17 @@
     FormValidation.I18n = $.extend(true, FormValidation.I18n || {}, {
         'en_US': {
             creditCard: {
-                'default': 'Please enter a valid credit card number'
+                'default': 'Please enter a valid credit card number',
+                'unsupported': 'The card number entered matches an unsupported card type: %s',
             }
         }
     });
-
+    
     FormValidation.Validator.creditCard = {
+        html5Attributes: {
+            supportedcards: 'supportedCards'
+        },
+
         /**
          * Return true if the input value is valid credit card number
          * Based on https://gist.github.com/DiegoSalazar/4075533
@@ -42,19 +47,29 @@
                 return false;
             }
 
+            var locale         = validator.getLocale();
+
+            if(options.supportedCards !== undefined)
+            {
+                var supportedCards = options.supportedCards.split(',');
+            }
+
             // Validate the card number based on prefix (IIN ranges) and length
             var cards = {
                 AMERICAN_EXPRESS: {
                     length: [15],
-                    prefix: ['34', '37']
+                    prefix: ['34', '37'],
+                    name: 'American Express'
                 },
                 DINERS_CLUB: {
                     length: [14],
-                    prefix: ['300', '301', '302', '303', '304', '305', '36']
+                    prefix: ['300', '301', '302', '303', '304', '305', '36'],
+                    name: 'Diners Club'
                 },
                 DINERS_CLUB_US: {
                     length: [16],
-                    prefix: ['54', '55']
+                    prefix: ['54', '55'],
+                    name: 'Diners Club US'
                 },
                 DISCOVER: {
                     length: [16],
@@ -63,38 +78,46 @@
                              '6222', '6223', '6224', '6225', '6226', '6227', '6228',
                              '62290', '62291', '622920', '622921', '622922', '622923',
                              '622924', '622925', '644', '645', '646', '647', '648',
-                             '649', '65']
+                             '649', '65'],
+                    name: 'Discover'
                 },
                 JCB: {
                     length: [16],
-                    prefix: ['3528', '3529', '353', '354', '355', '356', '357', '358']
+                    prefix: ['3528', '3529', '353', '354', '355', '356', '357', '358'],
+                    name: 'JCB'
                 },
                 LASER: {
                     length: [16, 17, 18, 19],
-                    prefix: ['6304', '6706', '6771', '6709']
+                    prefix: ['6304', '6706', '6771', '6709'],
+                    name: 'Laser'
                 },
                 MAESTRO: {
                     length: [12, 13, 14, 15, 16, 17, 18, 19],
-                    prefix: ['5018', '5020', '5038', '6304', '6759', '6761', '6762', '6763', '6764', '6765', '6766']
+                    prefix: ['5018', '5020', '5038', '6304', '6759', '6761', '6762', '6763', '6764', '6765', '6766'],
+                    name: 'Maestro'
                 },
                 MASTERCARD: {
                     length: [16],
-                    prefix: ['51', '52', '53', '54', '55']
+                    prefix: ['51', '52', '53', '54', '55'],
+                    name: 'MasterCard'
                 },
                 SOLO: {
                     length: [16, 18, 19],
-                    prefix: ['6334', '6767']
+                    prefix: ['6334', '6767'],
+                    name: 'Solo'
                 },
                 UNIONPAY: {
                     length: [16, 17, 18, 19],
                     prefix: ['622126', '622127', '622128', '622129', '62213', '62214',
                              '62215', '62216', '62217', '62218', '62219', '6222', '6223',
                              '6224', '6225', '6226', '6227', '6228', '62290', '62291',
-                             '622920', '622921', '622922', '622923', '622924', '622925']
+                             '622920', '622921', '622922', '622923', '622924', '622925'],
+                    name: 'Union Pay'
                 },
                 VISA: {
                     length: [16],
-                    prefix: ['4']
+                    prefix: ['4'],
+                    name: 'Visa'
                 }
             };
 
@@ -104,10 +127,22 @@
                     if (value.substr(0, cards[type].prefix[i].length) === cards[type].prefix[i]     // Check the prefix
                         && $.inArray(value.length, cards[type].length) !== -1)                      // and length
                     {
-                        return {
-                            valid: true,
-                            type: type
-                        };
+                        if(supportedCards !== undefined && $.inArray(type, supportedCards) == -1)  // Catch unsupported cards (if the field is on)
+                        {
+                            return {
+                                valid: false,
+                                message: FormValidation.Helper.format(options.message || FormValidation.I18n[locale].creditCard['unsupported'], cards[type].name),
+                                type: type
+                            };
+                        }
+                        else
+                        {
+                            return {
+                                valid: true,
+                                message: options.message || FormValidation.I18n[locale].creditCard['default'], 
+                                type: type
+                            };
+                        }
                     }
                 }
             }


### PR DESCRIPTION
I've added a HTML5 attribute `data-fv-creditcard-supportedcards` where you can enter a CSV of the supported cards.

```
<input type="text" name="cc" "data-fv-creditcard-supportedcards"="VISA,AMEX">
```

When a card is valid, and the user has entered a valid card number but an unsupported card it will cause a message `The card number entered matches an unsupported card type: %s`

Let me know your thoughts as my second direction was to consider refactoring it to only look at the prefix (so the entire card does not have to be valid before it prompts the user).
